### PR TITLE
fix typo "no key was not found"

### DIFF
--- a/sdk/lib/collection/splay_tree.dart
+++ b/sdk/lib/collection/splay_tree.dart
@@ -658,7 +658,7 @@ final class SplayTreeMap<K, V> extends _SplayTree<K, _SplayTreeMapNode<K, V>>
 
   /// The last key in the map that is strictly smaller than [key].
   ///
-  /// Returns `null` if no key was not found.
+  /// Returns `null` if such a key was not found.
   K? lastKeyBefore(K key) {
     if (key == null) throw ArgumentError(key);
     if (_root == null) return null;
@@ -675,7 +675,7 @@ final class SplayTreeMap<K, V> extends _SplayTree<K, _SplayTreeMapNode<K, V>>
   }
 
   /// Get the first key in the map that is strictly larger than [key]. Returns
-  /// `null` if no key was not found.
+  /// `null` if such a key was not found.
   K? firstKeyAfter(K key) {
     if (key == null) throw ArgumentError(key);
     if (_root == null) return null;


### PR DESCRIPTION
I think that the double negation "no key was not found" does not correctly explain the behavior of `firstKeyAfter` and `lastKeyAfter` of `SplayTreeMap`. I replaced it with "such a key was not found".

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.

Note that this repository uses Gerrit for code reviews. Your pull request will be automatically converted into a Gerrit CL and a link to the CL written into this PR. The review will happen on Gerrit but you can also push additional commits to this PR to update the code review.
</details>
